### PR TITLE
Merged changes from jmb-dev

### DIFF
--- a/WEQ2.Settings.iss
+++ b/WEQ2.Settings.iss
@@ -5,6 +5,9 @@ objectdef weq2settings
     variable int IndicatorX=20
     variable int IndicatorY=28
     variable bool LockGamma=FALSE
+    variable bool LockWindow=FALSE
+    variable bool ForceWindowed=TRUE
+
     variable bool UseEQPlayNice=FALSE
     variable float RenderStrobeInterval=1.0
     variable filepath AgentFolder="${Script.CurrentDirectory~}"
@@ -33,6 +36,8 @@ objectdef weq2settings
             "IndicatorX":${IndicatorX.AsJSON~},
             "IndicatorY":${IndicatorY.AsJSON~},
             "LockGamma":${LockGamma.AsJSON~},
+            "ForceWindowed":${ForceWindowed.AsJSON~},
+            "LockWindow":${LockWindow.AsJSON~},
             "EQPlayNice":${UseEQPlayNice.AsJSON~},
             "RenderStrobeInterval":${RenderStrobeInterval.AsJSON~},
             "BackgroundFPS":${BackgroundFPS.AsJSON~},
@@ -79,6 +84,12 @@ objectdef weq2settings
 
         if ${jo.Has[LockGamma]}
             LockGamma:Set["${jo.Get[LockGamma]~}"]
+
+        if ${jo.Has[LockWindow]}
+            LockWindow:Set["${jo.Get[LockWindow]~}"]
+
+        if ${jo.Has[ForceWindowed]}
+            ForceWindowed:Set["${jo.Get[ForceWindowed]~}"]
 
         if ${jo.Has[EQPlayNice]}
             UseEQPlayNice:Set["${jo.Get[EQPlayNice]~}"]

--- a/WEQ2022.Session.iss
+++ b/WEQ2022.Session.iss
@@ -31,9 +31,9 @@ objectdef weq2022session
     ; Object constructor
     method Initialize()
     {
-        if ${JMB.Build}<6877
+        if ${JMB.Build}<6881
         {
-            echo "WinEQ 2022 requires JMB build 6877 or later"
+            echo "WinEQ 2022 requires JMB build 6881 or later"
             return
         }
 
@@ -89,15 +89,13 @@ objectdef weq2022session
             EQPlayNice:SetCeiling["${Math.Calc[${Settings.RenderStrobeInterval}*1000]}"]
         }
 
-        if ${Settings.LockGamma}
-            GammaLock on
-
         if ${Settings.ForegroundFPS}
             maxfps -fg -calculate ${Settings.ForegroundFPS}
         if ${Settings.BackgroundFPS}
             maxfps -bg -calculate ${Settings.BackgroundFPS}
-            
-        This:SetForceWindow[1]
+        
+        This:SetLockGamma[${Settings.LockGamma}]
+        This:SetForceWindowed[${Settings.ForceWindowed}]
 
         if ${CurrentProfile.Adapter}>=0
         {
@@ -205,7 +203,7 @@ objectdef weq2022session
 
     method OnWindowPosition()
     {
-;        echo OnWindowPosition
+;        echo OnWindowPosition min=${Display.Window.IsMinimized} max=${Display.Window.IsMaximized} alwaysontop=${Display.Window.AlwaysOnTop} visible=${Display.Window.IsVisible}
     }
 
     method OnActivate()
@@ -241,14 +239,28 @@ objectdef weq2022session
 
     method SetForceAdapter(int numAdapter)
     {
+        CurrentProfile.Adapter:Set[${numAdapter}]
         noop ${Direct3D8:SetAdapter[${numAdapter}]} ${Direct3D9:SetAdapter[${numAdapter}]}
     }
 
-    method SetForceWindow(bool value)
+    method SetForceWindowed(bool value)
 	{
-			noop ${Direct3D8:SetForceWindowed[${value}]} ${Direct3D9:SetForceWindowed[${value}]} ${Direct3D10:SetForceWindowed[${value}]} ${Direct3D11:SetForceWindowed[${value}]}				
+        Settings.ForceWindowed:Set[${value}]
+        noop ${Direct3D8:SetForceWindowed[${value}]} ${Direct3D9:SetForceWindowed[${value}]} ${Direct3D10:SetForceWindowed[${value}]} ${Direct3D11:SetForceWindowed[${value}]}				
 	}
 
+    method SetLockWindow(bool value)
+    {
+        Settings.LockWindow:Set[${value}]
+        if ${value}
+        {
+            windowcharacteristics -lock
+        }
+        else
+        {
+            windowcharacteristics -unlock
+        }
+    }
 
     ; Installs a Hotkey, given a name, a key combination, and LavishScript code to execute on PRESS
     method InstallHotkey(string name, string keyCombo, string methodName)
@@ -499,7 +511,7 @@ objectdef weq2022session
         if !${Display.Window(exists)}
             return
 
-;        WindowCharacteristics -lock
+        This:SetLockWindow[${Settings.LockWindow}]
 
         echo "Performing game window setup ..."
 

--- a/WEQ2022.Session.iss
+++ b/WEQ2022.Session.iss
@@ -634,7 +634,7 @@ objectdef weq2022session
         {
             ; full screen! note that the 0,0 position used here is the primary display.
             ; TODO: alter this code to support correct positioning for multiple monitors
-            WindowCharacteristics -stealth -size -viewable fullscreen -pos -viewable 0,0 -frame none -visibility foreground
+            WindowCharacteristics -stealth -size -viewable fullscreen -pos -viewable ${Display.Monitor.Left},${Display.Monitor.Top} -frame none -visibility foreground
             return
         }
 
@@ -667,10 +667,15 @@ objectdef weq2022session
         sizeX:Set[${Display.Width}*${useScale}]
         sizeY:Set[${Display.Height}*${useScale}]
 
+        variable uint posX
+        variable uint posY
+        posX:Set[${Display.Monitor.Left}+${CurrentPreset.X}]
+        posY:Set[${Display.Monitor.Top}+${CurrentPreset.Y}]
+
         if ${useScale}!=1.0
-            WindowCharacteristics -stealth -pos -viewable ${CurrentPreset.X},${CurrentPreset.Y} -size -viewable ${sizeX}x${sizeY} ${useAlwaysOnTop}${useBorder}
+            WindowCharacteristics -stealth -pos -viewable ${posX},${posY} -size -viewable ${sizeX}x${sizeY} ${useAlwaysOnTop}${useBorder}
         else
-            WindowCharacteristics -pos -viewable ${CurrentPreset.X},${CurrentPreset.Y} -size -viewable ${sizeX}x${sizeY} ${useAlwaysOnTop}${useBorder}
+            WindowCharacteristics -pos -viewable ${posX},${posY} -size -viewable ${sizeX}x${sizeY} ${useAlwaysOnTop}${useBorder}
         
     }
 

--- a/WEQ2022.Session.iss
+++ b/WEQ2022.Session.iss
@@ -89,11 +89,8 @@ objectdef weq2022session
             EQPlayNice:SetCeiling["${Math.Calc[${Settings.RenderStrobeInterval}*1000]}"]
         }
 
-        if ${Settings.ForegroundFPS}
-            maxfps -fg -calculate ${Settings.ForegroundFPS}
-        if ${Settings.BackgroundFPS}
-            maxfps -bg -calculate ${Settings.BackgroundFPS}
-        
+        This:SetForegroundFPS[${Settings.ForegroundFPS}]
+        This:SetBackgroundFPS[${Settings.BackgroundFPS}]        
         This:SetLockGamma[${Settings.LockGamma}]
         This:SetForceWindowed[${Settings.ForceWindowed}]
 

--- a/WEQ2022.Uplink.iss
+++ b/WEQ2022.Uplink.iss
@@ -405,6 +405,26 @@ objectdef weq2022
         Settings:ExportJSON
     }
 
+    method SetLockWindow(bool newValue)
+    {
+        if ${newValue}==${Settings.LockWindow}
+            return
+
+        Settings.LockWindow:Set[${newValue}]
+        relay all -noredirect "WEQ2022Session:SetLockWindow[${newValue}]"
+        Settings:ExportJSON
+    }
+
+    method SetForceWindowed(bool newValue)
+    {
+        if ${newValue}==${Settings.ForceWindowed}
+            return
+
+        Settings.ForceWindowed:Set[${newValue}]
+        relay all -noredirect "WEQ2022Session:SetForceWindowed[${newValue}]"
+        Settings:ExportJSON
+    }
+
     method SetUseEQPlayNice(bool newValue)
     {
         if ${newValue}==${Settings.UseEQPlayNice}

--- a/WEQ2022.Uplink.lgui2Package.json
+++ b/WEQ2022.Uplink.lgui2Package.json
@@ -374,6 +374,28 @@
                                                 "pullFormat":"${WEQ2022.Settings.LockGamma}",
                                                 "pushFormat":["WEQ2022:SetLockGamma[","]"]
                                             }
+                                        },
+                                        {
+                                            "type":"checkbox",
+                                            "margin":[0,5,0,0],
+                                            "_dock":"top",
+                                            "content":"Force Windowed (in fullscreen mode)",
+                                            "tooltip":"When enabled, prevents the game from actually entering exclusive full screen mode, instead emulating it.\nOriginal WinEQ 2 permanently ENABLED this setting.",
+                                            "checkedBinding":{
+                                                "pullFormat":"${WEQ2022.Settings.ForceWindowed}",
+                                                "pushFormat":["WEQ2022:SetForceWindowed[","]"]
+                                            }
+                                        },
+                                        {
+                                            "type":"checkbox",
+                                            "margin":[0,5,0,0],
+                                            "_dock":"top",
+                                            "content":"Lock Window Characteristics",
+                                            "tooltip":"When enabled, prevents the game from moving or adjusting the window in any way, and will also prevent the window from minimizing.",
+                                            "checkedBinding":{
+                                                "pullFormat":"${WEQ2022.Settings.LockWindow}",
+                                                "pushFormat":["WEQ2022:SetLockWindow[","]"]
+                                            }
                                         }
                                     ]
                                 }

--- a/agent.json
+++ b/agent.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://www.lavishsoft.com/schema/agent.json",
     "name": "WinEQ 2022",
-    "version": "20220302.2",
+    "version": "20220305.1",
     "minimumBuild": 6881,
     "platforms": {
         "joe multiboxer uplink": {

--- a/agent.json
+++ b/agent.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://www.lavishsoft.com/schema/agent.json",
     "name": "WinEQ 2022",
-    "version": "20220305.1",
+    "version": "20220324.1",
     "minimumBuild": 6881,
     "platforms": {
         "joe multiboxer uplink": {


### PR DESCRIPTION
- New `Force Windowed` option in the General tab can be un-checked to allow the game to enter full screen mode. Original WinEQ 2 forced this option, here it is provided as default.
- New `Lock Window Characteristics` in the General tab can be checked to prevent the game from altering the game window (e.g. moving or resizing), and will also prevent the window from minimizing
- disabled FPS settings should now properly apply at launch
- Window Presets should apply on the current monitor